### PR TITLE
Improve Caça‑Niquel2 logic

### DIFF
--- a/"a/Ca\303\247a-Niquel2/game.js"
+++ b/"a/Ca\303\247a-Niquel2/game.js"
@@ -1,0 +1,73 @@
+const GAME_STATE = {
+  credits: 1000,
+  bet: 50,
+  totalSpins: 0,
+  totalWins: 0,
+};
+
+const SYMBOLS = ['🍒', '🍊', '🍋', '🍇', '🔔', '💎'];
+const PAYOUTS = {
+  '🍒🍒🍒': 100,
+  '🍊🍊🍊': 150,
+  '🍋🍋🍋': 200,
+  '🍇🍇🍇': 300,
+  '🔔🔔🔔': 500,
+  '💎💎💎': 1000,
+};
+
+const updateDisplay = () => {
+  const creditsEl = document.getElementById('credits');
+  const betEl = document.getElementById('bet');
+  if (creditsEl) creditsEl.textContent = GAME_STATE.credits;
+  if (betEl) betEl.textContent = GAME_STATE.bet;
+};
+
+const changeBet = (delta) => {
+  const newBet = GAME_STATE.bet + delta;
+  GAME_STATE.bet = Math.max(25, Math.min(newBet, GAME_STATE.credits));
+  updateDisplay();
+};
+
+const getRandomSymbol = () =>
+  SYMBOLS[Math.floor(Math.random() * SYMBOLS.length)];
+
+const checkWin = (r1, r2, r3) => {
+  const combo = r1 + r2 + r3;
+  if (PAYOUTS[combo]) return PAYOUTS[combo] * GAME_STATE.bet;
+  if (r1 === r2 || r1 === r3 || r2 === r3) return GAME_STATE.bet * 2;
+  return 0;
+};
+
+const spin = () => {
+  if (GAME_STATE.credits < GAME_STATE.bet) return null;
+  GAME_STATE.credits -= GAME_STATE.bet;
+
+  const reel1 = getRandomSymbol();
+  const reel2 = getRandomSymbol();
+  const reel3 = getRandomSymbol();
+
+  const win = checkWin(reel1, reel2, reel3);
+  if (win > 0) {
+    GAME_STATE.credits += win;
+    GAME_STATE.totalWins += 1;
+  }
+  GAME_STATE.totalSpins += 1;
+
+  updateDisplay();
+  return { reels: [reel1, reel2, reel3], win };
+};
+
+const clearHistory = () => {
+  const historyEl = document.getElementById('gameHistory');
+  if (historyEl) historyEl.innerHTML = '';
+};
+
+if (typeof module !== 'undefined') {
+  module.exports = {
+    GAME_STATE,
+    changeBet,
+    spin,
+    clearHistory,
+    updateDisplay,
+  };
+}

--- a/"a/Ca\303\247a-Niquel2/manifest.json"
+++ b/"a/Ca\303\247a-Niquel2/manifest.json"
@@ -1,0 +1,20 @@
+{
+  "name": "Caça-níquel da Fortuna",
+  "short_name": "Caça-níquel",
+  "start_url": "./index.html",
+  "display": "standalone",
+  "background_color": "#1e1b4b",
+  "theme_color": "#1e1b4b",
+  "icons": [
+    {
+      "src": "icons/icon-192x192.png",
+      "sizes": "192x192",
+      "type": "image/png"
+    },
+    {
+      "src": "icons/icon-512x512.png",
+      "sizes": "512x512",
+      "type": "image/png"
+    }
+  ]
+}

--- a/"a/Ca\303\247a-Niquel2/navigation.js"
+++ b/"a/Ca\303\247a-Niquel2/navigation.js"
@@ -1,0 +1,24 @@
+const toggleMobileMenu = () => {
+  const menu = document.getElementById('mobileMenu');
+  if (menu) {
+    menu.classList.toggle('hidden');
+  }
+};
+
+const showSection = (id) => {
+  document.querySelectorAll('.section').forEach((sec) => {
+    if (sec.id === id) {
+      sec.classList.add('active');
+    } else {
+      sec.classList.remove('active');
+    }
+  });
+  const menu = document.getElementById('mobileMenu');
+  if (menu) {
+    menu.classList.add('hidden');
+  }
+};
+
+if (typeof module !== 'undefined') {
+  module.exports = { toggleMobileMenu, showSection };
+}

--- a/"b/Ca\303\247a-Niquel2/settings.js"
+++ b/"b/Ca\303\247a-Niquel2/settings.js"
@@ -1,0 +1,22 @@
+const SETTINGS = {
+  soundVolume: 50,
+  musicVolume: 75,
+  visualEffects: true,
+  reducedAnimations: false,
+};
+
+document.getElementById('soundVolume')?.addEventListener('input', (e) => {
+  SETTINGS.soundVolume = parseInt(e.target.value, 10);
+  const span = document.getElementById('soundVolumeValue');
+  if (span) span.textContent = `${SETTINGS.soundVolume}%`;
+});
+
+document.getElementById('musicVolume')?.addEventListener('input', (e) => {
+  SETTINGS.musicVolume = parseInt(e.target.value, 10);
+  const span = document.getElementById('musicVolumeValue');
+  if (span) span.textContent = `${SETTINGS.musicVolume}%`;
+});
+
+if (typeof module !== 'undefined') {
+  module.exports = { SETTINGS };
+}


### PR DESCRIPTION
## Summary
- expand `game.js` with basic slot logic and exports
- refactor navigation helpers to arrow functions
- expose settings manager for Node

## Testing
- `node Caça-Niquel2/tests.js` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6846f8db0250832c9fc0d42b86b8e67e