### PR TITLE
Enable add-to-cart buttons

### DIFF
--- a/printify-site/assets/js/main.js
+++ b/printify-site/assets/js/main.js
@@ -243,17 +243,17 @@ class PrintifyApp {
     setupEventListeners() {
       // Botões de "Add to Cart"
       document.addEventListener('click', (e) => {
-        if (e.target.matches('button:contains("Add to Cart")') || e.target.closest('button')?.textContent.includes('Add to Cart')) {
+        const button = e.target.closest('[data-add-to-cart]');
+        if (button) {
           e.preventDefault();
-          
-          // Dados mock do produto - em produção viria de uma API
+
           const productData = {
-            id: Date.now().toString(),
-            name: 'Produto 3D',
-            price: 29.99,
-            image: 'https://via.placeholder.com/200'
+            id: button.dataset.id || Date.now().toString(),
+            name: button.dataset.name || 'Produto 3D',
+            price: parseFloat(button.dataset.price) || 29.99,
+            image: button.dataset.image || 'https://via.placeholder.com/200'
           };
-          
+
           this.addToCart(productData);
         }
       });

--- a/printify-site/index.html
+++ b/printify-site/index.html
@@ -214,20 +214,26 @@
                       background-image: url(&quot;https://lh3.googleusercontent.com/aida-public/AB6AXuDJifGozFwzb7kVKh8SxrSrmEjcj92UrSEH8wgW6C5sU56xZFYJcBj1JNkdcWrkbnn7SLs-VuWUbFTv7dVjdesLVu3cS21Gd3xqkt-AGV6V7eYy4app2ad9thOPg_YEnPyeNDiCTeYfUZi4sVNT9SQRqdAc3K95ZbbsL419O4FYWUvBp6XHSir82zyE_yMMU3dKAw6GAqt5d7V8C6-_pfiPO2lWi5UcdRzV6g4SINo5MabmTfrqzYDPBY8_F6MaBEqweb5urt4d3zWW&quot;);
                     "
                   ></div>
-                  <div class="p-4">
-                    <p
-                      class="text-gray-900 text-lg font-semibold leading-normal"
-                    >
-                      Modern Vase
-                    </p>
-                    <p
-                      class="text-gray-600 text-sm font-normal leading-normal mt-1"
-                    >
-                      Elegant design for any space
-                    </p>
-                    <p class="text-[#e92933] text-lg font-bold mt-2">$49.99</p>
-                  </div>
                 </a>
+                <div class="p-4 pt-0">
+                  <p class="text-gray-900 text-lg font-semibold leading-normal">
+                    <a href="product.html">Modern Vase</a>
+                  </p>
+                  <p class="text-gray-600 text-sm font-normal leading-normal mt-1">
+                    Elegant design for any space
+                  </p>
+                  <p class="text-[#e92933] text-lg font-bold mt-2">$49.99</p>
+                  <button
+                    class="mt-3 w-full rounded-lg h-10 bg-[#e92933] hover:bg-red-700 text-white text-sm font-semibold transition-colors"
+                    data-add-to-cart
+                    data-id="vase-001"
+                    data-name="Modern Vase"
+                    data-price="49.99"
+                    data-image="https://lh3.googleusercontent.com/aida-public/AB6AXuDJifGozFwzb7kVKh8SxrSrmEjcj92UrSEH8wgW6C5sU56xZFYJcBj1JNkdcWrkbnn7SLs-VuWUbFTv7dVjdesLVu3cS21Gd3xqkt-AGV6V7eYy4app2ad9thOPg_YEnPyeNDiCTeYfUZi4sVNT9SQRqdAc3K95ZbbsL419O4FYWUvBp6XHSir82zyE_yMMU3dKAw6GAqt5d7V8C6-_pfiPO2lWi5UcdRzV6g4SINo5MabmTfrqzYDPBY8_F6MaBEqweb5urt4d3zWW"
+                  >
+                    Add to Cart
+                  </button>
+                </div>
               </div>
               <div
                 class="flex flex-col gap-3 rounded-lg bg-white shadow-md hover:shadow-xl transition-shadow duration-300 overflow-hidden group"
@@ -239,20 +245,26 @@
                       background-image: url(&quot;https://lh3.googleusercontent.com/aida-public/AB6AXuD3cpKYUx-6Dcl0O08oZM7u9exr2TWMf8-8O1QEvXssN1GcmIMhFqDPLaT3SAA6m9EZXa_sUIc8yngU6O5cULcZYMHdzq8kHdIYfau0uvae4-oT1PyK89e4tdWXK8VWS_RqAlx0QQGUI4WXW0f2FUlBStTRfi0mmwdWd4kzWzMqLPoAHdDmd19tsjgWMGUTKFbE0J_8NKVlrwwrnrSkwXI7zEjNMGmn7PdggZVV5DFsCsVreCKmy9XEF2LHgzuWNr1Q2H2u9YlD7DT_&quot;);
                     "
                   ></div>
-                  <div class="p-4">
-                    <p
-                      class="text-gray-900 text-lg font-semibold leading-normal"
-                    >
-                      Abstract Sculpture
-                    </p>
-                    <p
-                      class="text-gray-600 text-sm font-normal leading-normal mt-1"
-                    >
-                      Unique art piece for your home
-                    </p>
-                    <p class="text-[#e92933] text-lg font-bold mt-2">$89.99</p>
-                  </div>
                 </a>
+                <div class="p-4 pt-0">
+                  <p class="text-gray-900 text-lg font-semibold leading-normal">
+                    <a href="product.html">Abstract Sculpture</a>
+                  </p>
+                  <p class="text-gray-600 text-sm font-normal leading-normal mt-1">
+                    Unique art piece for your home
+                  </p>
+                  <p class="text-[#e92933] text-lg font-bold mt-2">$89.99</p>
+                  <button
+                    class="mt-3 w-full rounded-lg h-10 bg-[#e92933] hover:bg-red-700 text-white text-sm font-semibold transition-colors"
+                    data-add-to-cart
+                    data-id="sculpture-001"
+                    data-name="Abstract Sculpture"
+                    data-price="89.99"
+                    data-image="https://lh3.googleusercontent.com/aida-public/AB6AXuD3cpKYUx-6Dcl0O08oZM7u9exr2TWMf8-8O1QEvXssN1GcmIMhFqDPLaT3SAA6m9EZXa_sUIc8yngU6O5cULcZYMHdzq8kHdIYfau0uvae4-oT1PyK89e4tdWXK8VWS_RqAlx0QQGUI4WXW0f2FUlBStTRfi0mmwdWd4kzWzMqLPoAHdDmd19tsjgWMGUTKFbE0J_8NKVlrwwrnrSkwXI7zEjNMGmn7PdggZVV5DFsCsVreCKmy9XEF2LHgzuWNr1Q2H2u9YlD7DT_"
+                  >
+                    Add to Cart
+                  </button>
+                </div>
               </div>
               <div
                 class="flex flex-col gap-3 rounded-lg bg-white shadow-md hover:shadow-xl transition-shadow duration-300 overflow-hidden group"
@@ -264,20 +276,26 @@
                       background-image: url(&quot;https://lh3.googleusercontent.com/aida-public/AB6AXuASz3NjXKjfOR0UiDjUk9fI7NzduaYtHynoasrFocZPbhoNz4bad84My8jn0SFk_2sLjKRUN3h02U0WYerffyCK4nyUIlLr4vl6IFyyKWm7LP8-UUDgYigkSHSRAEVHfTYIsZoVHY9MA-p7V_-vu-2bXL4eb7lde-1ULAV0oiF6ZdPY8Vtt-XjmZsBsqPzubeS8RJIv9uRLb9PUg1-uRxAs3TN2AWjE3o0MdcsAbFd01nrjiax9yKXjGW25M48vjuWhSJvYPXCIlDc7&quot;);
                     "
                   ></div>
-                  <div class="p-4">
-                    <p
-                      class="text-gray-900 text-lg font-semibold leading-normal"
-                    >
-                      Geometric Lamp
-                    </p>
-                    <p
-                      class="text-gray-600 text-sm font-normal leading-normal mt-1"
-                    >
-                      Ambient lighting with a modern touch
-                    </p>
-                    <p class="text-[#e92933] text-lg font-bold mt-2">$65.00</p>
-                  </div>
                 </a>
+                <div class="p-4 pt-0">
+                  <p class="text-gray-900 text-lg font-semibold leading-normal">
+                    <a href="product.html">Geometric Lamp</a>
+                  </p>
+                  <p class="text-gray-600 text-sm font-normal leading-normal mt-1">
+                    Ambient lighting with a modern touch
+                  </p>
+                  <p class="text-[#e92933] text-lg font-bold mt-2">$65.00</p>
+                  <button
+                    class="mt-3 w-full rounded-lg h-10 bg-[#e92933] hover:bg-red-700 text-white text-sm font-semibold transition-colors"
+                    data-add-to-cart
+                    data-id="lamp-001"
+                    data-name="Geometric Lamp"
+                    data-price="65.00"
+                    data-image="https://lh3.googleusercontent.com/aida-public/AB6AXuASz3NjXKjfOR0UiDjUk9fI7NzduaYtHynoasrFocZPbhoNz4bad84My8jn0SFk_2sLjKRUN3h02U0WYerffyCK4nyUIlLr4vl6IFyyKWm7LP8-UUDgYigkSHSRAEVHfTYIsZoVHY9MA-p7V_-vu-2bXL4eb7lde-1ULAV0oiF6ZdPY8Vtt-XjmZsBsqPzubeS8RJIv9uRLb9PUg1-uRxAs3TN2AWjE3o0MdcsAbFd01nrjiax9yKXjGW25M48vjuWhSJvYPXCIlDc7"
+                  >
+                    Add to Cart
+                  </button>
+                </div>
               </div>
               <div
                 class="flex flex-col gap-3 rounded-lg bg-white shadow-md hover:shadow-xl transition-shadow duration-300 overflow-hidden group"
@@ -289,20 +307,26 @@
                       background-image: url(&quot;https://lh3.googleusercontent.com/aida-public/AB6AXuCy4E6YqWA-6K01WEo8UGX5AO_BDVc90eIcl2K4upXllcX3pEu7LC7Dw781LGuzQUwHCmsxRUMeqoLf1rC0wPWc2pyJKICARhCEWsxDmJZ7eSegeTZ5EKqtIW2mcztg0TO3lLUGoI6FVfHafaoD2XQjPv4FgRKTi47aGH-fFQU719hLYC0ZecxsG6PALgK9vd8nY7_9jdpuIJEY1yPT1iI7BBOayRg9xoCFZFZpoCgTsVDqf_ctTKK_icX-2hhyFcUuKxtfJUcemUg1&quot;);
                     "
                   ></div>
-                  <div class="p-4">
-                    <p
-                      class="text-gray-900 text-lg font-semibold leading-normal"
-                    >
-                      Custom Phone Case
-                    </p>
-                    <p
-                      class="text-gray-600 text-sm font-normal leading-normal mt-1"
-                    >
-                      Personalized protection for your device
-                    </p>
-                    <p class="text-[#e92933] text-lg font-bold mt-2">$29.50</p>
-                  </div>
                 </a>
+                <div class="p-4 pt-0">
+                  <p class="text-gray-900 text-lg font-semibold leading-normal">
+                    <a href="product.html">Custom Phone Case</a>
+                  </p>
+                  <p class="text-gray-600 text-sm font-normal leading-normal mt-1">
+                    Personalized protection for your device
+                  </p>
+                  <p class="text-[#e92933] text-lg font-bold mt-2">$29.50</p>
+                  <button
+                    class="mt-3 w-full rounded-lg h-10 bg-[#e92933] hover:bg-red-700 text-white text-sm font-semibold transition-colors"
+                    data-add-to-cart
+                    data-id="case-001"
+                    data-name="Custom Phone Case"
+                    data-price="29.50"
+                    data-image="https://lh3.googleusercontent.com/aida-public/AB6AXuCy4E6YqWA-6K01WEo8UGX5AO_BDVc90eIcl2K4upXllcX3pEu7LC7Dw781LGuzQUwHCmsxRUMeqoLf1rC0wPWc2pyJKICARhCEWsxDmJZ7eSegeTZ5EKqtIW2mcztg0TO3lLUGoI6FVfHafaoD2XQjPv4FgRKTi47aGH-fFQU719hLYC0ZecxsG6PALgK9vd8nY7_9jdpuIJEY1yPT1iI7BBOayRg9xoCFZFZpoCgTsVDqf_ctTKK_icX-2hhyFcUuKxtfJUcemUg1"
+                  >
+                    Add to Cart
+                  </button>
+                </div>
               </div>
             </div>
           </section>

--- a/printify-site/product.html
+++ b/printify-site/product.html
@@ -225,7 +225,11 @@
                   <p class="text-primary text-3xl font-bold mb-4">$29.99</p>
                   <button
                     class="flex w-full items-center justify-center rounded-lg h-12 px-6 bg-primary text-white text-base font-bold leading-normal tracking-wide hover:bg-red-700 transition-colors focus:outline-none focus:ring-2 focus:ring-offset-2 ring-primary"
-                    onclick="addToCart({id: 'vase-001', name: '3D Printed Vase', price: 29.99, image: 'https://lh3.googleusercontent.com/aida-public/AB6AXuCcL61OwaazqR4m0vkbKMZawCda_NYKRyw1o1IiSK8vYtEjv1csTF93MOq6AzTWiuT7f061PVpdjpRLqUAXxUhrXxgR7Z10CHK0J3GgNYVAICTVA7s1rvq4cChUUj9pa2Ki6XaKt5QsCltoMyuISharnkTYWPYIjqw-tMpWGht1MxDqJmeexDafjbEoX_SIeJijSiVJ7RZAfW9Tnlxj3CgQHR2w0Um5DmCGK_ugLOu49oSfCTC4rN9oHoML5XN0kbGW9mutgkE4bi5i'})"
+                    data-add-to-cart
+                    data-id="vase-001"
+                    data-name="3D Printed Vase"
+                    data-price="29.99"
+                    data-image="https://lh3.googleusercontent.com/aida-public/AB6AXuCcL61OwaazqR4m0vkbKMZawCda_NYKRyw1o1IiSK8vYtEjv1csTF93MOq6AzTWiuT7f061PVpdjpRLqUAXxUhrXxgR7Z10CHK0J3GgNYVAICTVA7s1rvq4cChUUj9pa2Ki6XaKt5QsCltoMyuISharnkTYWPYIjqw-tMpWGht1MxDqJmeexDafjbEoX_SIeJijSiVJ7RZAfW9Tnlxj3CgQHR2w0Um5DmCGK_ugLOu49oSfCTC4rN9oHoML5XN0kbGW9mutgkE4bi5i"
                   >
                     <span class="truncate">Add to Cart</span>
                   </button>


### PR DESCRIPTION
## Summary
- enable JavaScript cart handler for `[data-add-to-cart]` buttons
- add Add to Cart buttons on the index page
- switch product page to data attributes instead of inline JS

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_684f54c479cc832cb19a502889147c87